### PR TITLE
Get rid of double quotes, dots in layout name

### DIFF
--- a/scripts/get_keyboard_layout.sh
+++ b/scripts/get_keyboard_layout.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | grep "KeyboardLayout Name" | cut -f 2 -d "=" | tr -d ' ;'
+defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources | grep "KeyboardLayout Name" | cut -f 2 -d "=" | tr -d ' ;."'


### PR DESCRIPTION
For some layouts (U.S for example) keyboard name in double quotes. But for Russian, Portuguese - not.